### PR TITLE
add tests for navbar

### DIFF
--- a/specs/0901-navbar.feature
+++ b/specs/0901-navbar.feature
@@ -1,0 +1,15 @@
+Feature: Navbar
+
+Scenario: Unauthorized user should only see home link
+Given standing on the landing page
+Then I should only see link to Home
+
+Scenario: Authorized user should se all links
+Given that I am logged in
+And standing on the landing page
+Then I should see all links 
+
+Scenario: Current page should be highlighted
+Given that I am logged in
+Given standing on the home page
+Then link to Home should look different compared to other links

--- a/specs/step_definitions/00-before-and-after-hooks.js
+++ b/specs/step_definitions/00-before-and-after-hooks.js
@@ -75,43 +75,45 @@ Before all tests, login as admin and add:
 - One private game
 - One public game
 And store them as cypress environment variables, so they can be reached from test cases.
-
-Then log out.
 */
 
 before(() => {
   //Log in as admin
-  cy.apiLogin("admin", "PasswordAdmin1!");
-  //Post new difficulty level
-  cy.makePost(
-    "https://localhost:7259/api/DifficultyLevel/PostDifficultyLevel",
-    newDifficultyLevel,
-    "newDifficultyLevel"
-  ).then(() => {
-    //Post new category
+  cy.apiLogin("admin", "PasswordAdmin1!").then(() => {
+    //Post new difficulty level
     cy.makePost(
-      "https://localhost:7259/api/Category",
-      newCategory,
-      "newCategory"
+      "https://localhost:7259/api/DifficultyLevel/PostDifficultyLevel",
+      newDifficultyLevel,
+      "newDifficultyLevel"
     ).then(() => {
-      //Get and set difficulty level-id
-      newPublicGame.DifficultyLevelId = Cypress.env("newDifficultyLevel").id;
-      newPrivateGame.DifficultyLevelId = Cypress.env("newDifficultyLevel").id;
-      //Get and set category id
-      newPublicGame.CategoryId = Cypress.env("newCategory").id;
-      newPrivateGame.CategoryId = Cypress.env("newCategory").id;
-      //Post public game
+      //Post new category
       cy.makePost(
-        "https://localhost:7259/api/game/PostGame",
-        newPublicGame,
-        "newPublicGame"
+        "https://localhost:7259/api/Category",
+        newCategory,
+        "newCategory"
       ).then(() => {
-        //Post private game
+        //Get and set difficulty level-id
+        newPublicGame.DifficultyLevelId = Cypress.env("newDifficultyLevel").id;
+        newPrivateGame.DifficultyLevelId = Cypress.env("newDifficultyLevel").id;
+        //Get and set category id
+        newPublicGame.CategoryId = Cypress.env("newCategory").id;
+        newPrivateGame.CategoryId = Cypress.env("newCategory").id;
+        //Post public game
         cy.makePost(
           "https://localhost:7259/api/game/PostGame",
-          newPrivateGame,
-          "newPrivateGame"
-        );
+          newPublicGame,
+          "newPublicGame"
+        ).then(() => {
+          //Post private game
+          cy.makePost(
+            "https://localhost:7259/api/game/PostGame",
+            newPrivateGame,
+            "newPrivateGame"
+          ).then(() => {
+            //Log out
+            cy.apiLogout();
+          });
+        });
       });
     });
   });
@@ -122,16 +124,18 @@ After all tests, delete everything that was added in the before hook.
 */
 
 after(() => {
-  //Delete category. By doing so, all created games related to that category will also be deleted automatically.
-  cy.cleanUp(
-    `https://localhost:7259/api/Category/DeleteCategory?categoryId=${newPrivateGame.CategoryId}`
-  ).then(() => {
-    //Remove difficulty level
+  cy.apiLogin("admin", "PasswordAdmin1!").then(() => {
+    //Delete category. By doing so, all created games related to that category will also be deleted automatically.
     cy.cleanUp(
-      `https://localhost:7259/api/DifficultyLevel/DeleteDifficultyLevel?difficultyLevelId=${newPrivateGame.DifficultyLevelId}`
+      `https://localhost:7259/api/Category/DeleteCategory?categoryId=${newPrivateGame.CategoryId}`
     ).then(() => {
-      //Log out
-      cy.apiLogout();
+      //Remove difficulty level
+      cy.cleanUp(
+        `https://localhost:7259/api/DifficultyLevel/DeleteDifficultyLevel?difficultyLevelId=${newPrivateGame.DifficultyLevelId}`
+      ).then(() => {
+        //Log out
+        cy.apiLogout();
+      });
     });
   });
 });

--- a/specs/step_definitions/0801-routing-error.js
+++ b/specs/step_definitions/0801-routing-error.js
@@ -1,8 +1,6 @@
 import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
 
 Given("that I am on the landing and try to enter wrong", () => {
-  // sign out för att inte vara authorized
-  cy.apiLogout();
   cy.visit("http://localhost:3007/landingpage");
 });
 

--- a/specs/step_definitions/0901-navbar.js
+++ b/specs/step_definitions/0901-navbar.js
@@ -1,0 +1,52 @@
+import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
+/*
+***
+Scenario: Unauthorized user should only see home link
+***
+*/
+Given("standing on the landing page", () => {
+  cy.visitLandingPage();
+});
+
+Then("I should only see link to Home", () => {
+  cy.get("#navbar-home-link").should("exist");
+  cy.get("#navbar-create-link").should("not.exist");
+  cy.get("#navbar-profile-link").should("not.exist");
+  cy.get("#navbar-logout-link").should("not.exist");
+});
+
+/*
+***
+Scenario: Authorized user should se all links
+***
+*/
+
+/* No duplicate steps, this one already in 0301-preview-category.js
+Given('that I am logged in', () => {});*/
+
+/* No duplicate steps, this one already above
+Given('standing on the landing page', () => {});*/
+
+Then("I should see all links", () => {
+  cy.get("#navbar-home-link").should("exist");
+  cy.get("#navbar-create-link").should("exist");
+  cy.get("#navbar-profile-link").should("exist");
+  cy.get("#navbar-logout-link").should("exist");
+});
+
+/*
+***
+Scenario: Current page should be highlighted
+***
+*/
+/* No duplicate steps, this one already in 0301-preview-category.js
+Given('that I am logged in', () => {});*/
+
+/* No duplicate steps, this one already in 0701-home-filter.js
+Given('standing on the home page', () => {});*/
+
+Then("link to Home should look different compared to other links", () => {
+  cy.get("#navbar-home-link").should("have.class", "active-link");
+  cy.get("#navbar-create-link").should("have.class", "inactive-link");
+  cy.get("#navbar-profile-link").should("have.class", "inactive-link");
+});

--- a/specs/step_definitions/0901-navbar.js.new
+++ b/specs/step_definitions/0901-navbar.js.new
@@ -1,0 +1,29 @@
+import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
+
+Given('standing on the landing page', () => {
+  // TODO: implement step
+});
+
+Then('I should only see link to Home', () => {
+  // TODO: implement step
+});
+
+/* No duplicate steps, this one already in 0301-preview-category.js
+Given('that I am logged in', () => {});*/
+
+/* No duplicate steps, this one already above
+Given('standing on the landing page', () => {});*/
+
+Then('I should see all links', () => {
+  // TODO: implement step
+});
+
+/* No duplicate steps, this one already in 0301-preview-category.js
+Given('that I am logged in', () => {});*/
+
+/* No duplicate steps, this one already in 0701-home-filter.js
+Given('standing on the home page', () => {});*/
+
+Then('link to Home should look different compared to other links', () => {
+  // TODO: implement step
+});

--- a/support/commands.js
+++ b/support/commands.js
@@ -2,6 +2,11 @@
 
 const baseUrl = require("../baseUrl");
 
+Cypress.Commands.add("visitLandingPage", () => {
+  cy.visit("/landingpage");
+  cy.url().should("include", "/landingpage");
+});
+
 Cypress.Commands.add("visitCreatePage", () => {
   cy.intercept("https://localhost:7259/api/category/GetCategories").as(
     "getCategoriesForCreatePage"


### PR DESCRIPTION
Alter before hook so that admin is logged out.
Alter after hook so that admin first logs in, creates the requests and then logs out.
This was needed to get a clean test process and make sure all tests always starts from unauthorized mode.
Removed logout-call in routing-error test because of the above change.

Add some testcases for navbar.
